### PR TITLE
Dark mode improvement and some cleanup

### DIFF
--- a/GoldenDict/styles/darkmode/article-style.css
+++ b/GoldenDict/styles/darkmode/article-style.css
@@ -203,14 +203,12 @@ code::selection
 {
 	background: white;
 }
-
+/*
 .dsl_s_wav img, .lsa_play img, .forvo_play img[alt="Play"]
 {
-  /**
   display: none;
-  **/
 }
-
+*/
 .dsl_s_wav a, .lsa_play td:nth-of-type(1) a, .forvo_play td:nth-of-type(1) a
 {
   color: white;
@@ -421,25 +419,27 @@ pre {
         text-indent: 15px;
         font-size:  medium;
 }
+/*
 i {
 }
+*/
 b {
         color: lightblue;
 }
 em.err {
         color: DeepSkyBlue;
         font-weight: bold;
-        font-stye: italic;
+        font-style: italic;
 }
 span.sel {
         color: #33A055;
 }
 span.img {
         font-size: small;
-        font-stye: italic;
+        font-style: italic;
 }
 img,svg {
-        vertical-alignment: super;
+        vertical-align: super;
         font-size: small;
         background: #f1f1f1;
         color: #f1f1f1;
@@ -454,18 +454,24 @@ sub {
 a {
         color: tomato;
 }
+/*
 a.ref {
 }
+*/
 a.cnd {
         color: lightyellow;
 }
+/*
 a.img {
 }
 a.snd {
 }
 a.mpg {
 }
+*/
 p {
+  margin-left: 10px;
+  margin-right: 10px;
 }
 .epwing_image {
   display: inline-block !important;
@@ -916,4 +922,9 @@ tr:last-child th:last-child { border-bottom-right-radius: 2px; }
   margin-right: 4px;
   margin-bottom: 4px;
   text-decoration: none;
+}
+
+.sdct_m {
+  margin-left: 10px;
+  margin-right: 10px;
 }

--- a/GoldenDict/styles/darkmode/qt-style.css
+++ b/GoldenDict/styles/darkmode/qt-style.css
@@ -2,18 +2,62 @@ MainWindow {
 	background: #222;
 	color: #D4D2CF;
 }
-MainWindow #searchPane #translateLine, MainWindow #searchPane #wordList
-{
+
+MainWindow #searchPane #translateLine, MainWindow #searchPane #wordList {
 	background: #222;
 	color: #D4D2CF;
 }
-MainWindow #favoritesPane #favoritesTree
-{
+
+MainWindow #favoritesPane #favoritesTree {
 	background: #222;
 	color: #D4D2CF;
 }
-MainWindow #translateLine, ScanPopup #translateLine, MainWindow #wordList, MainWindow #dictsPane #dictsList, MainWindow #historyPane #historyList
-{
+
+MainWindow #translateLine, ScanPopup #translateLine, MainWindow #wordList, MainWindow #dictsPane #dictsList, MainWindow #historyPane #historyList {
 	background: #222;
 	color: #D4D2CF
+}
+
+/* New additions */
+
+/* Make the labels for various panes white ("History", "Found in Dictionaries", etc.). */
+MainWindow #searchPane QLabel, MainWindow #favoritesPane QLabel, MainWindow #dictsPane QLabel, MainWindow #historyPane QLabel {
+	background: #222;
+	color: #D4D2CF;
+}
+
+/* Make the Group drop-down box black in Navbar, when Search pane is not enabled.  */
+MainWindow #navToolbar GroupComboBox, MainWindow #navToolbar GroupComboBox::hover, MainWindow #navToolbar GroupComboBox::pressed {
+	background: #222;
+	color: #D4D2CF;
+}
+
+/* Make the Group drop-down box black in Search pane. */
+MainWindow #searchPane GroupComboBox {
+	background: #222;
+	color: #D4D2CF;
+	border: 1px solid #D4D2CF;
+}
+
+/* Make dictionary names white when [View>Show Names in Dictionary Bar] is enabled. */
+MainWindow #dictionaryBar QWidget {
+	background: #222;
+	color: #D4D2CF;
+	padding: 1px;
+}
+
+/* Make the menubar (File, View, Edit, Etc.) black. */
+MainWindow #menubar {
+	background: #222;
+	color: #D4D2CF;
+}
+
+MainWindow #menubar::item:selected {
+	background: #1F2D39;
+	border: 1px solid #1B374E;
+}
+
+MainWindow #menubar::item:pressed {
+	background: #1B374E;
+	border: 1px solid #144C7A;
 }


### PR DESCRIPTION
Hi! This PR is mainly stuff I mentioned in https://github.com/goldendict/goldendict/issues/1352 a couple of months ago.

`qt-style.css` has been updated to improve the appearance of dark mode. Details can be found in comments in the file.

`article-style.css` has been modified in the following ways:
- A couple of typos have been fixed.
- Empty rulesets have been commented out (mainly to shut up my own linter, but I guess it spares a couple of CPU cycles).
- Added the `.sdct_m` class. Both it and `p` have been given 10px margins on both sides in order to keep text from touching the edges of the window. `.sdct_m` affects dictionary entries, while `p` affects everything else.

Hope you like it!